### PR TITLE
[Fixed]: Updated careers.html

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -125,7 +125,7 @@
                     <div class="col-lg-3 col-md-6 footer-links">
                         <h4>About Us</h4>
                         <ul>
-                            <li><i class="ion-ios-arrow-forward"></i> <a href="/index.html#home">Home</a></li>
+                            <li><i class="ion-ios-arrow-forward"></i> <a href="/index.html">Home</a></li>
                             <li><i class="ion-ios-arrow-forward"></i> <a href="/Team.html">Team</a></li>
                             <li><i class="ion-ios-arrow-forward"></i> <a href="/index.html#home">Reviews</a></li>
                             <!-- <li><i class="ion-ios-arrow-forward"></i> <a href="#">Terms & condition</a></li> -->


### PR DESCRIPTION
Describe the Update
A clear and concise description of what the bug is.
Fixed the Link for Home page on Careers Page.
To Reproduce
Steps to reproduce the behavior:

1. Go to footer of Home page'
2. Click on 'Careers'
3. Scroll down to 'Footer and click on Home in ABOUT US '


Additional context
Add any other context about the problem here.

